### PR TITLE
GHA: use a matrix to create images of different kallithea-version

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -77,8 +77,8 @@ jobs:
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
           tags: |
-            ghcr.io/${{ github.repository }}:${{ github.ref_name }}-${{ github.sha }}
-            ghcr.io/${{ github.repository }}:latest
+            ghcr.io/svenroederer/docker-kallithea-toras9000:${{ github.ref_name }}-${{ github.sha }}
+            ghcr.io/svenroederer/docker-kallithea-toras9000:latest
 
       - name: Refresh cache
         run: |

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -77,7 +77,7 @@ jobs:
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
           tags: |
-            ghcr.io/${{ github.repository }}:${{ github.ref }}
+            ghcr.io/${{ github.repository }}:${{ github.ref_name }}-${{ github.sha }}
             ghcr.io/${{ github.repository }}:latest
 
       - name: Refresh cache

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -8,7 +8,7 @@ name: Docker
 on:
   push:
     branches:
-#      - 'main'
+      - 'main'
       - 'v*.*.*'
   workflow_dispatch:
     inputs:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -36,13 +36,6 @@ jobs:
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@v2.5.0
 
-      - name: Log into registry Docker Hub
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@v2.1.0
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
       - name: Log into registry ghcr.io
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v2.1.0

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -8,8 +8,7 @@ name: Docker
 on:
   push:
     branches:
-      - 'main'
-      - 'v*.*.*'
+      - '*'
   workflow_dispatch:
     inputs:
       with_latest:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -73,10 +73,12 @@ jobs:
           context: ./build
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+          tags: |
+            ghcr.io/${{ github.repository }}:${{ github.ref }}
+            ghcr.io/${{ github.repository }}:latest
 
       - name: Refresh cache
         run: |

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -19,6 +19,10 @@ on:
 jobs:
   build:
 
+    strategy:
+      matrix:
+        kallithea_version: [0.6.0, 0.6.1, 0.6.2, 0.6.3, 0.7.0]
+
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -76,8 +80,9 @@ jobs:
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
           tags: |
-            ghcr.io/svenroederer/docker-kallithea-toras9000:${{ github.ref_name }}-${{ github.sha }}
-            ghcr.io/svenroederer/docker-kallithea-toras9000:latest
+            ghcr.io/svenroederer/docker-kallithea-toras9000:${{ matrix.kallithea_version }}-${{ github.ref_name }}.${{ github.sha }}
+            ghcr.io/svenroederer/docker-kallithea-toras9000:${{ matrix.kallithea_version }}-latest
+          build-args: KALLITHEA_VER=${{ matrix.kallithea_version }}
 
       - name: Refresh cache
         run: |


### PR DESCRIPTION
While working on #2 I looked for an easy way of creating image for multiple Kallithea-versions automatically.
As for v0.6.0 on you changes only involve bumping the versionnumber, I replaced this by a matrix in Github-Actions.

Aa v0.5.x images contain some manual patches, I excluded them for the moment, but I  can add this steps. As v0.5.x series is python2 based code, I personally do not consider this anymore, as python2 is EOL anyways.


P.S: the initial PR contains some code to disable upload to DockerHub and only pushes to Github-ContainerRegistry, as I don't have an account  there.  But action-file should be easily made compatible again.